### PR TITLE
filter nested keys in without()

### DIFF
--- a/lib/Rethinkdb/Query.pm
+++ b/lib/Rethinkdb/Query.pm
@@ -564,7 +564,7 @@ sub pluck {
 
 sub without {
   my $self = shift;
-  my $args = @_ ? @_ > 1 ? [@_] : [ @{ $_[0] } ] : [];
+  my $args = [@_];
 
   my $q = Rethinkdb::Query->new(
     _parent => $self,

--- a/t/document.t
+++ b/t/document.t
@@ -298,6 +298,23 @@ is_deeply $res->response,
   },
   'Correct response';
 
+
+# remove nested key(s)
+$res = r->table('marvel')->get('Iron Man')
+    ->without( 'personalVictoriesList', 'equipment', { stuff => { laserCannons => r->true } } )->run;
+
+is $res->type, 1, 'Correct response type';
+is_deeply $res->response,
+  {
+  reactorState => 'medium',
+  reactorPower => 4500,
+  age          => 30,
+  superhero    => 'Iron Man',
+  stuff        => { missels => 12 },
+  },
+  'Correct response';
+
+
 # Insert a value in to an array at a given index. Returns the modified array.
 $res = r->expr( [ 'Iron Man', 'Spider-Man' ] )->insert_at( 1, 'Hulk' )
   ->run($conn);


### PR DESCRIPTION
Hopefully I didn't break any use cases, but all tests pass.  I was unable to filter nested keys at all before these changes.